### PR TITLE
feat: add fully configurable announcement formats and platform colors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.ccoding</groupId>
   <artifactId>LiveAnnounce</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>jar</packaging>
   <name>LiveAnnounce</name>
 

--- a/src/main/java/org/ccoding/liveannounce/LiveAnnounce.java
+++ b/src/main/java/org/ccoding/liveannounce/LiveAnnounce.java
@@ -5,6 +5,7 @@ import org.ccoding.liveannounce.commands.DirectoCommand;
 import org.ccoding.liveannounce.commands.LiveAnnounceCommand;
 import org.ccoding.liveannounce.managers.MessageManager;
 import org.ccoding.liveannounce.managers.PrefixManager;
+import org.ccoding.liveannounce.utils.AnnouncementFormatter;
 
 public class LiveAnnounce extends JavaPlugin {
 
@@ -21,6 +22,7 @@ public class LiveAnnounce extends JavaPlugin {
         // Cargamos los managers
         PrefixManager.load(getConfig());
         MessageManager.setup(getConfig());
+        AnnouncementFormatter.initialize(getConfig());
 
         // Verificar si el plugin está habilitado
         if (!getConfig().getBoolean("enabled", true)) {
@@ -52,5 +54,6 @@ public class LiveAnnounce extends JavaPlugin {
         reloadConfig();
         PrefixManager.load(getConfig());
         MessageManager.reload(getConfig());
+        AnnouncementFormatter.reload(getConfig());
     }
 }

--- a/src/main/java/org/ccoding/liveannounce/commands/DirectoCommand.java
+++ b/src/main/java/org/ccoding/liveannounce/commands/DirectoCommand.java
@@ -7,6 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.ccoding.liveannounce.LiveAnnounce;
 import org.ccoding.liveannounce.managers.MessageManager;
+import org.ccoding.liveannounce.utils.AnnouncementFormatter;
 import org.ccoding.liveannounce.utils.ChatUtils;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
@@ -108,36 +109,21 @@ public class DirectoCommand implements CommandExecutor {
         return new PlatformInfo("Directo", "&6");
     }
 
-    // Crear mensaje con el mismo FORMATO visual
+    // Actualizamos para que utilice AnnouncementFormatter y sea editable
     private void sendClickableBroadcast(String playerName, PlatformInfo platform, String link) {
+        // Usar el nuevo formatter
+        TextComponent[] components = AnnouncementFormatter.createAnnouncement(
+                playerName,
+                platform.name,
+                platform.color,
+                link
+        );
 
-        TextComponent line1 = new TextComponent(ChatUtils.color(ChatUtils.getLine()));
-
-        TextComponent title = new TextComponent(ChatUtils.color(
-                "&f⚡ " + platform.color + "&lLIVE ON " + platform.name.toUpperCase() + "! &f⚡"
-        ));
-
-        TextComponent desc = new TextComponent(ChatUtils.color(
-                "&f" + playerName + " &7is streaming live"
-        ));
-
-        TextComponent url = new TextComponent(ChatUtils.color(
-                "&7Join now! " + platform.color + "&n" + link
-        ));
-        url.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, link));
-        url.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                new ComponentBuilder(ChatUtils.color("&eClick to open!")).create()
-        ));
-
-        TextComponent line2 = new TextComponent(ChatUtils.color(ChatUtils.getLine()));
-
-        // Global broadcast
+        // Envío global
         for (Player p : Bukkit.getOnlinePlayers()) {
-            p.spigot().sendMessage(line1);
-            p.spigot().sendMessage(title);
-            p.spigot().sendMessage(desc);
-            p.spigot().sendMessage(url);
-            p.spigot().sendMessage(line2);
+            for (TextComponent component : components) {
+                p.spigot().sendMessage(component);
+            }
         }
     }
 

--- a/src/main/java/org/ccoding/liveannounce/utils/AnnouncementFormatter.java
+++ b/src/main/java/org/ccoding/liveannounce/utils/AnnouncementFormatter.java
@@ -1,0 +1,202 @@
+package org.ccoding.liveannounce.utils;
+
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.ccoding.liveannounce.LiveAnnounce;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnnouncementFormatter {
+
+    private static final Map<String, String> FORMATS = new HashMap<>();
+    private static boolean initialized = false;
+
+    private AnnouncementFormatter() {}
+
+    public static void initialize(FileConfiguration config){
+        if (initialized) return;
+
+        ConfigurationSection formatsSection = config.getConfigurationSection("announcement-formats.default");
+        if (formatsSection == null) {
+            loadDefaultFormats();
+            return;
+        }
+
+        // Cargar cada parte del formato
+        FORMATS.put("line1", formatsSection.getString("line1", getDefault("line1")));
+        FORMATS.put("title", formatsSection.getString("title", getDefault("title")));
+        FORMATS.put("description", formatsSection.getString("description", getDefault("description")));
+        FORMATS.put("link", formatsSection.getString("link", getDefault("link")));
+        FORMATS.put("hover", formatsSection.getString("hover", getDefault("hover")));
+        FORMATS.put("line2", formatsSection.getString("line2", getDefault("line2")));
+
+        initialized = true;
+        LiveAnnounce.getInstance().getLogger().info("Announcement formats loaded: " + FORMATS.size() + " components");
+    }
+
+    private static void loadDefaultFormats() {
+        FORMATS.put("line1", "&8&m--------------------------------------------------");
+        FORMATS.put("title", "&f⚡ {color}&l¡LIVE ON {platform_upper}! &f⚡");
+        FORMATS.put("description", "&f{player} &7is now streaming live");
+        FORMATS.put("link", "&7Join now! {color}&n{link}");
+        FORMATS.put("hover", "&eClick to open the stream!");
+        FORMATS.put("line2", "&8&m--------------------------------------------------");
+
+        initialized = true;
+        LiveAnnounce.getInstance().getLogger().info("Loaded default announcement formats");
+    }
+
+    private static  String getDefault(String key) {
+        return FORMATS.getOrDefault(key, "&7[" + key + "]");
+    }
+
+    public static TextComponent[] createAnnouncement(String playerName, String platformName,
+                                                     String platformColor, String link) {
+
+        if (!initialized) {
+            LiveAnnounce.getInstance().getLogger().warning("AnnouncementFormatter not initialized!");
+            return new TextComponent[0];
+        }
+
+        // Obtener color desde config (IGNORAR el platformColor que viene del comando)
+        String colorFromConfig = getPlatformColor(platformName.toLowerCase());
+
+        // Preparar variables
+        Map<String, String> variables = new HashMap<>();
+        variables.put("player", playerName);
+        variables.put("platform", platformName);
+        variables.put("platform_upper", platformName.toUpperCase());
+        variables.put("color", colorFromConfig);  // ← Usar "color" no "platform_color"
+        variables.put("link", link);
+
+        // Extraer channel del link (opcional)
+        String channel = extractChannel(link);
+        variables.put("channel", channel != null ? channel : playerName);
+
+        // DEBUG: Mostrar valores
+        System.out.println("[DEBUG] Platform: " + platformName);
+        System.out.println("[DEBUG] Color from config: '" + colorFromConfig + "'");
+        System.out.println("[DEBUG] Template title: " + FORMATS.get("title"));
+
+        // Crear componentes
+        return new TextComponent[] {
+                createLine("line1", variables),
+                createTitle("title", variables),
+                createDescription("description", variables),
+                createClickableLink("link", "hover", variables, link),
+                createLine("line2", variables)
+        };
+    }
+
+    private static TextComponent createLine(String formatKey, Map<String, String> variables) {
+        String text = applyVariablesWithColor(FORMATS.get(formatKey), variables);
+        return new TextComponent(ChatUtils.color(text));
+    }
+
+    private static TextComponent createTitle(String formatKey, Map<String, String> variables) {
+        String text = applyVariablesWithColor(FORMATS.get(formatKey), variables);
+        return new TextComponent(ChatUtils.color(text));
+    }
+
+    private static TextComponent createDescription(String formatKey, Map<String, String> variables) {
+        String text = applyVariablesWithColor(FORMATS.get(formatKey), variables);
+        return new TextComponent(ChatUtils.color(text));
+    }
+
+    private static TextComponent createClickableLink(String formatKey, String hoverKey,
+                                                     Map<String, String> variables, String link) {
+        String text = applyVariablesWithColor(FORMATS.get(formatKey), variables);
+        String hoverText = applyVariablesWithColor(FORMATS.get(hoverKey), variables);
+
+        TextComponent component = new TextComponent(ChatUtils.color(text));
+        component.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, link));
+        component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                new ComponentBuilder(ChatUtils.color(hoverText)).create()));
+
+        return component;
+    }
+
+    private static String applyVariablesWithColor(String template, Map<String, String> variables) {
+        if (template == null) return "";
+
+        String result = template;
+
+        // Reemplazar TODAS las variables
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            String placeholder = "{" + entry.getKey() + "}";
+            result = result.replace(placeholder, entry.getValue());
+        }
+
+        return result;
+    }
+
+    private static String extractChannel(String link) {
+        try {
+            // Simple extracción: twitch.tv/{canal}
+            if (link.contains("twitch.tv/")) {
+                return link.substring(link.indexOf("twitch.tv/") + 10).split("/")[0];
+            }
+            // youtube.com/{canal} o youtu.be/{id}
+            else if (link.contains("youtube.com/")) {
+                return link.substring(link.indexOf("youtube.com/") + 12).split("/")[0];
+            }
+            else if (link.contains("youtu.be/")) {
+                return link.substring(link.indexOf("youtu.be/") + 9);
+            }
+            // kick.com/{canal}
+            else if (link.contains("kick.com/")) {
+                return link.substring(link.indexOf("kick.com/") + 9);
+            }
+            // tiktok.com/@{canal}
+            else if (link.contains("tiktok.com/@")) {
+                return link.substring(link.indexOf("tiktok.com/@") + 12).split("/")[0];
+            }
+        } catch (Exception e) {
+            // Si falla la extracción, usar player name
+        }
+        return null;
+    }
+
+    public static void reload(FileConfiguration config) {
+        FORMATS.clear();
+        initialized = false;
+        initialize(config);
+    }
+
+    public static boolean isInitialized() {
+        return initialized;
+    }
+
+    public static int getFormatCount() {
+        return FORMATS.size();
+    }
+
+    private static String getPlatformColor(String platformKey) {
+        // Intentar obtener desde config
+        String color = LiveAnnounce.getInstance().getConfig()
+                .getString("platform-colors." + platformKey);
+
+        // Si no existe usar default
+        if (color == null || color.trim().isEmpty()) {
+            color = LiveAnnounce.getInstance().getConfig()
+                    .getString("platform-colors.default", "&6");
+        }
+
+        // Asegurar que empiece con & y tenga formato correcto
+        if (!color.startsWith("&") && color.length() >= 1) {
+            color = "&" + color;
+        }
+
+        // Asegurar formato & + letra (ej: &d, &c)
+        if (color.length() == 2 && color.startsWith("&")) {
+            return color;
+        }
+
+        return color;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,3 +22,21 @@ messages:
   # Status messages
   status-enabled: "&7Status: &aEnabled"
   status-disabled: "&7Status: &cDisabled"
+
+# ========== PLATFORM COLORS CONFIGURATION ==========
+platform-colors:
+  twitch: "&d"      # Purple
+  youtube: "&c"     # Red
+  kick: "&a"        # Green
+  tiktok: "&b"      # Aqua
+  default: "&6"     # Gold
+
+# ========== ANNOUNCEMENT FORMAT CONFIGURATION ==========
+announcement-formats:
+  default:
+    line1: "&8&m--------------------------------------------------"
+    title: "&f⚡ {color}&l¡LIVE ON {platform_upper}! &f⚡"  # ← Usa {color}
+    description: "&f{player} &7is now streaming live"
+    link: "&7Join now! {color}&n{link}"  # ← Usa {color}
+    hover: "&eClick to open the stream!"
+    line2: "&8&m--------------------------------------------------"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: LiveAnnounce
-version: 1.0.3
+version: 1.0.4
 main: org.ccoding.liveannounce.LiveAnnounce
 api-version: "1.16"
 author: ccoding


### PR DESCRIPTION
## New Features
- Fully configurable announcement formats - Customize every part of stream announcements
- Platform-specific colors - Set different colors for Twitch, YouTube, Kick, TikTok
- Dynamic variables - Use {player}, {platform}, {color}, {link}, {channel} in your formats

## Customization Examples
```yaml
platform-colors:
  twitch: "&d"    # Purple
  youtube: "&c"   # Red
  kick: "&a"      # Green

announcement-formats:
  default:
    title: "&f⚡ {color}&l¡LIVE ON {platform_upper}! &f⚡"
    description: "&f{player} &7is now streaming live"
    link: "&7Join now! {color}&n{link}"