### PR TITLE
feat: add per-player cooldown system for announcements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.ccoding</groupId>
   <artifactId>LiveAnnounce</artifactId>
-  <version>1.1</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
   <name>LiveAnnounce</name>
 

--- a/src/main/java/org/ccoding/liveannounce/LiveAnnounce.java
+++ b/src/main/java/org/ccoding/liveannounce/LiveAnnounce.java
@@ -3,6 +3,7 @@ package org.ccoding.liveannounce;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.ccoding.liveannounce.commands.DirectoCommand;
 import org.ccoding.liveannounce.commands.LiveAnnounceCommand;
+import org.ccoding.liveannounce.managers.CooldownManager;
 import org.ccoding.liveannounce.managers.MessageManager;
 import org.ccoding.liveannounce.managers.PrefixManager;
 import org.ccoding.liveannounce.utils.AnnouncementFormatter;
@@ -10,6 +11,7 @@ import org.ccoding.liveannounce.utils.AnnouncementFormatter;
 public class LiveAnnounce extends JavaPlugin {
 
     private static LiveAnnounce instance;
+    private CooldownManager announcementCooldown;
 
     @Override
     public void onEnable() {
@@ -31,6 +33,13 @@ public class LiveAnnounce extends JavaPlugin {
             return;
         }
 
+        boolean cooldownEnabled = getConfig().getBoolean("cooldown.enabled", true);
+        int cooldownSeconds = getConfig().getInt("cooldown.seconds", 30);
+
+        if (cooldownEnabled) {
+            announcementCooldown = new CooldownManager(cooldownSeconds);
+        }
+
         this.getCommand("directo").setExecutor(new DirectoCommand());
         this.getCommand("liveannounce").setExecutor(new LiveAnnounceCommand());
 
@@ -50,10 +59,22 @@ public class LiveAnnounce extends JavaPlugin {
         return instance;
     }
 
+    public CooldownManager getAnnouncementCooldown(){
+        return announcementCooldown;
+    }
+
     public void reloadPlugin() {
         reloadConfig();
         PrefixManager.load(getConfig());
         MessageManager.reload(getConfig());
         AnnouncementFormatter.reload(getConfig());
+        boolean cooldownEnabled = getConfig().getBoolean("cooldown.enabled", true);
+        int cooldownSeconds = getConfig().getInt("cooldown.seconds", 30);
+
+        if (cooldownEnabled) {
+            announcementCooldown = new CooldownManager(cooldownSeconds);
+        } else {
+            announcementCooldown = null;
+        }
     }
 }

--- a/src/main/java/org/ccoding/liveannounce/commands/DirectoCommand.java
+++ b/src/main/java/org/ccoding/liveannounce/commands/DirectoCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.ccoding.liveannounce.LiveAnnounce;
 import org.ccoding.liveannounce.managers.AnnouncementPipeline;
 import org.ccoding.liveannounce.managers.AnnouncementService;
+import org.ccoding.liveannounce.managers.CooldownManager;
 import org.ccoding.liveannounce.managers.MessageManager;
 import org.ccoding.liveannounce.utils.AnnouncementFormatter;
 import org.ccoding.liveannounce.utils.ChatUtils;
@@ -30,6 +31,19 @@ public class DirectoCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+
+        CooldownManager cooldown = LiveAnnounce.getInstance().getAnnouncementCooldown();
+
+        if (cooldown != null && !cooldown.canUse(player.getUniqueId())) {
+            long remaining = cooldown.getRemaining(player.getUniqueId());
+
+            String message = LiveAnnounce.getInstance().getConfig().getString("cooldown.message", "&cYou must wait {time}s.");
+
+            player.sendMessage(ChatUtils.color(
+                    message.replace("{time}", String.valueOf(remaining))
+            ));
+            return true;
+        }
 
         if (!player.hasPermission("liveannounce.directo") && !player.isOp()) {
             ChatUtils.sendMessage(player, MessageManager.get("no-permission"));
@@ -60,6 +74,9 @@ public class DirectoCommand implements CommandExecutor {
                 platformName,
                 link);
 
+        if (cooldown != null) {
+            cooldown.apply(player.getUniqueId());
+        }
         return true;
     }
 

--- a/src/main/java/org/ccoding/liveannounce/managers/CooldownManager.java
+++ b/src/main/java/org/ccoding/liveannounce/managers/CooldownManager.java
@@ -1,0 +1,61 @@
+package org.ccoding.liveannounce.managers;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CooldownManager {
+
+    /**
+     * Guarda el momento (en ms) en el que el jugador puede volver
+     * a usar el comando
+     */
+    private final Map<UUID, Long> cooldowns = new ConcurrentHashMap<>();
+
+    // Cooldown en milisegundos
+    private final long cooldownMillis;
+
+    public CooldownManager(long cooldownSeconds) {
+        this.cooldownMillis = cooldownSeconds * 1000L;
+    }
+
+    // Verifica si el jugador puede usar el comando
+    public boolean canUse(UUID uuid) {
+        Long expiresAt = cooldowns.get(uuid);
+
+        // No tiene cooldown
+        if (expiresAt == null) {
+            return true;
+        }
+
+        // Cooldown expirado -> Lo limpia
+        if (System.currentTimeMillis() >= expiresAt) {
+            cooldowns.remove(uuid);
+            return true;
+        }
+
+        return false;
+    }
+
+    // Aplica el cooldown al jugador
+    public void apply(UUID uuid) {
+        cooldowns.put(uuid, System.currentTimeMillis() + cooldownMillis);
+    }
+
+    // Obtiene el tiempo restante en segundos
+    public long getRemaining(UUID uuid) {
+        Long expiresAt = cooldowns.get(uuid);
+
+        if (expiresAt == null) {
+            return 0;
+        }
+
+        long remaining = expiresAt - System.currentTimeMillis();
+        return Math.max(0, remaining / 1000);
+    }
+
+    // Limpia todos los cooldowns
+    public void clear() {
+        cooldowns.clear();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,3 +40,9 @@ announcement-formats:
     link: "&7Join now! {color}&n{link}"  # ← Usa {color}
     hover: "&eClick to open the stream!"
     line2: "&8&m--------------------------------------------------"
+
+# ========== COOLDOWN ==========
+cooldown:
+  enabled: true
+  seconds: 30
+  message: "&cYou must wait {time}s before using this command again."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: LiveAnnounce
-version: 1.1
+version: 1.1.1
 main: org.ccoding.liveannounce.LiveAnnounce
 api-version: "1.16"
 author: ccoding


### PR DESCRIPTION
Mejoras de Rendimiento:
- Implementación de un sistema de cooldown por jugador para evitar spam de comandos
- Prevención de ejecuciones innecesarias del sistema de anuncios

Nuevas Funcionalidades:
- Cooldown configurable desde el config.yml
- Mensaje de cooldown personalizable con placeholder {time}
- Aplicación del cooldown únicamente al comando de anuncios

Optimizaciones Internas:
- Uso de UUIDs para un control eficiente por jugador
- Lógica de cooldown centralizada en un CooldownManager
- Reinicio correcto del cooldown al recargar el plugin